### PR TITLE
refactor: tracking 통합, UI 블로킹 제거, config 시스템 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,8 @@ env/
 ._*
 
 # App specific
-.mac_timetracker/
-*.log 
+.mactimetracker/
+*.log
+
+# Generated test files
+test_import.py

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 ksbelphegor
+Copyright (c) 2026 ksbelphegor
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 PyQt5>=5.15.0
 pyobjc-core>=9.0
-pyobjc-framework-Cocoa>=9.0 
+pyobjc-framework-Cocoa>=9.0

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ import os
 # 앱 정보
 APP_NAME = 'Mac Time Tracker'
 MAIN_SCRIPT = 'src/main.py'
-VERSION = '1.0.1'
+VERSION = '1.1.1'
 
 # 아이콘 파일 (없으면 기본 아이콘 사용)
 ICON_FILE = None

--- a/src/core/app_tracker.py
+++ b/src/core/app_tracker.py
@@ -6,35 +6,25 @@ from AppKit import NSWorkspace, NSApplicationActivationPolicyRegular
 from src.core.config import APP_NAME, BUNDLE_ID, CONFIG
 import os
 
+logger = logging.getLogger(__name__)
+
+
 class AppTracker:
     """
     앱 추적 로직을 처리하는 클래스
-    
+
     이 클래스는 macOS에서 실행 중인 앱들의 사용 시간을 추적하고 관리합니다.
     NSWorkspace API를 사용하여 현재 활성화된 앱 정보를 가져오고,
     각 앱의 사용 시간을 기록하며, 창(윈도우) 단위로 세부 사용 시간을 추적합니다.
-    
-    Attributes:
-        data_manager: 데이터 저장 및 로드를 담당하는 DataManager 인스턴스
-        our_pid: 현재 프로세스의 PID
-        our_bundle_id: 현재 앱의 번들 ID
-        our_app_name: 현재 앱의 이름
-        current_date: 현재 날짜 (YYYY-MM-DD 형식)
-        app_usage: 앱 사용 데이터를 저장하는 딕셔너리
-        _window_title_cache: 창 제목 캐시
-        _app_list_cache: 실행 중인 앱 목록 캐시
-        _last_app_update: 마지막 앱 목록 업데이트 시간
-        _last_window_check: 마지막 창 확인 시간
-        _window_check_interval: 창 확인 간격 (초)
-        _app_cache_lifetime: 앱 캐시 수명 (초)
-        _cache_cleanup_counter: 캐시 정리 카운터
-        running_apps: 현재 실행 중인 앱 목록
+
+    이 클래스가 단일 데이터 기록자(Writer) 역할을 하며,
+    UI 위젯(AppTrackingWidget)은 DataManager를 통해 읽기 전용으로만 접근합니다.
     """
-    
+
     def __init__(self, data_manager):
         """
         AppTracker 초기화
-        
+
         Args:
             data_manager: 데이터 저장 및 로드를 담당하는 DataManager 인스턴스
         """
@@ -42,7 +32,7 @@ class AppTracker:
         self.our_pid = os.getpid()
         self.our_bundle_id = BUNDLE_ID
         self.our_app_name = APP_NAME
-        
+
         # 기본 데이터 초기화
         self.current_date = datetime.datetime.now().date().strftime('%Y-%m-%d')
         loaded_usage = self.data_manager.load_app_usage()
@@ -53,7 +43,7 @@ class AppTracker:
         self.app_usage['dates'].setdefault(self.current_date, {})
         # 타이머 누적값 스냅샷
         self._last_timer_totals = {}
-        
+
         # 캐시 및 상태 관리
         self._window_title_cache = {}
         self._app_list_cache = set()
@@ -62,19 +52,19 @@ class AppTracker:
         self._window_check_interval = 1.0
         self._app_cache_lifetime = CONFIG["cache"]["app_lifetime"]
         self._cache_cleanup_counter = 0
-        
+
         # 실행 중인 앱 목록
         self.running_apps = set()
-        
-        logging.info("AppTracker 초기화 완료")
-    
+
+        logger.info("AppTracker 초기화 완료")
+
     def get_active_window_title(self):
         """
         현재 활성 창의 제목을 가져옵니다.
-        
+
         NSWorkspace API를 사용하여 현재 활성화된 앱 정보를 가져오고,
         해당 앱의 이름과 창 제목을 반환합니다.
-        
+
         Returns:
             tuple: (앱 이름, 창 제목) 형태의 튜플. 정보를 가져올 수 없는 경우 (None, None) 반환
         """
@@ -84,72 +74,73 @@ class AppTracker:
             active_app = workspace.activeApplication()
             if not active_app:
                 return None, None
-            
+
             app_name = active_app['NSApplicationName']
-            
+
             # 현재 앱이 우리 앱인 경우 처리
             if active_app['NSApplicationProcessIdentifier'] == self.our_pid:
                 return app_name, "App"
-            
+
             # 시스템 앱은 제외
             skip_apps = {'Finder', 'SystemUIServer', 'loginwindow', 'Dock', 'Control Center', 'Notification Center'}
             if app_name in skip_apps:
                 return app_name, app_name
-            
+
             # 캐시 확인
             cache_key = f"{app_name}_{active_app['NSApplicationProcessIdentifier']}"
             current_time = time_module.time()
-            
-            if (cache_key in self._window_title_cache and 
+
+            if (cache_key in self._window_title_cache and
                 current_time - self._window_title_cache[cache_key]['time'] < 10.0):
                 return app_name, self._window_title_cache[cache_key]['title']
-            
+
             # 캐시 업데이트
             window_title = app_name
             self._window_title_cache[cache_key] = {
                 'title': window_title,
                 'time': current_time
             }
-            
+
             # 주기적으로 캐시 정리 (100회마다)
             self._cache_cleanup_counter += 1
             if self._cache_cleanup_counter >= 100:
                 self._cleanup_cache()
                 self._cache_cleanup_counter = 0
-            
+
             return app_name, window_title
-            
+
         except Exception as e:
-            print(f"활성 창 정보 가져오기 실패: {e}")
+            logger.error(f"활성 창 정보 가져오기 실패: {e}")
             return None, None
-    
+
     def _cleanup_cache(self):
         """오래된 캐시 항목을 정리합니다."""
         try:
             current_time = time_module.time()
             expired_keys = []
-            
+
             for key, data in self._window_title_cache.items():
                 if current_time - data['time'] > 300:  # 5분 이상 지난 항목 제거
                     expired_keys.append(key)
-            
+
             for key in expired_keys:
                 del self._window_title_cache[key]
-                
-            print(f"{len(expired_keys)}개의 캐시 항목 정리됨")
-            
+
+            if expired_keys:
+                logger.debug(f"{len(expired_keys)}개의 캐시 항목 정리됨")
+
         except Exception as e:
-            print(f"캐시 정리 중 오류 발생: {e}")
-    
+            logger.error(f"캐시 정리 중 오류 발생: {e}")
+
     def update_app_list(self):
         """실행 중인 앱 목록을 업데이트합니다."""
         current_time = time_module.time()
-        
+
         # 캐시가 유효한 경우 캐시된 앱 리스트 사용
-        if (current_time - self._last_app_update < self._app_cache_lifetime and 
+        if (current_time - self._last_app_update < self._app_cache_lifetime and
             self._app_list_cache):
             return self._app_list_cache
-        
+
         # 앱 리스트 업데이트
         new_apps = set()
         for app in NSWorkspace.sharedWorkspace().runningApplications():
@@ -157,33 +148,33 @@ class AppTracker:
                 app_name = app.localizedName()
                 if app_name:
                     new_apps.add(app_name)
-        
+
         # 변경사항이 있을 때만 업데이트
         if new_apps != self._app_list_cache:
             self.running_apps = new_apps
             self._app_list_cache = new_apps.copy()
             self._last_app_update = current_time
-        
+
         return self._app_list_cache
-    
+
     def update_usage_stats(self, timer_data):
         """현재 실행 중인 앱의 시간을 업데이트합니다."""
         try:
             if not timer_data or not timer_data.get('app_name'):
                 return
-                
+
             current_time = time_module.time()
             current_date = datetime.datetime.now().date().strftime('%Y-%m-%d')
-            
+
             # 날짜가 변경되었는지 확인
             if current_date != self.current_date:
                 # 새로운 날짜의 데이터 초기화
                 if current_date not in self.app_usage['dates']:
                     self.app_usage['dates'][current_date] = {}
-                
+
                 # 현재 날짜 업데이트
                 self.current_date = current_date
-            
+
             # 현재 활성화된 앱의 시간 업데이트
             app_name = timer_data['app_name']
             app_records = self.app_usage['dates'][current_date]
@@ -221,11 +212,11 @@ class AppTracker:
             app_data['is_active'] = timer_data.get('is_active', False)
             app_data['last_update'] = current_time
             self._last_timer_totals[app_name] = baseline_total
-            
+
         except Exception as e:
-            print(f"앱 사용 통계 업데이트 중 오류 발생: {e}")
+            logger.error(f"앱 사용 통계 업데이트 중 오류 발생: {e}")
             traceback.print_exc()
-    
+
     def save_app_usage(self):
         """앱 사용 통계를 저장합니다."""
-        self.data_manager.save_app_usage(self.app_usage) 
+        self.data_manager.save_app_usage(self.app_usage)

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -7,10 +7,9 @@ from logging.handlers import RotatingFileHandler
 # 앱 정보
 APP_NAME = "Mac 타임좌"
 BUNDLE_ID = "com.ksbelphegor.mactimetracker"
-APP_VERSION = "1.0.0"
+APP_VERSION = "1.1.1"
 
 # 디렉토리 설정
-HOME_DIR = str(Path.home())
 DATA_DIR = os.path.expanduser("~/.mactimetracker")
 APP_USAGE_FILE = os.path.join(DATA_DIR, 'app_usage.json')
 TIMER_DATA_FILE = os.path.join(DATA_DIR, 'timer_data.json')
@@ -25,13 +24,13 @@ DEFAULT_CONFIG = {
         "cleanup_interval": 3600,  # 1시간마다 캐시 정리
         "app_lifetime": 2.0,       # 앱 캐시 수명 (초)
     },
-    
+
     # 데이터 관리 설정
     "data_management": {
         "save_interval": 60,       # 데이터 저장 간격 (초)
         "retention_days": 30,      # 데이터 보관 기간 (일)
     },
-    
+
     # UI 설정
     "ui": {
         "app_list_update_interval": 10000,  # 앱 목록 업데이트 간격 (밀리초)
@@ -40,7 +39,7 @@ DEFAULT_CONFIG = {
         "status_bar_height": 22,
         "icon_size": 20,
     },
-    
+
     # 로깅 설정
     "logging": {
         "level": "INFO",
@@ -49,26 +48,17 @@ DEFAULT_CONFIG = {
     }
 }
 
-# 기존 설정 유지를 위한 변수들
-APP_CACHE_LIFETIME = DEFAULT_CONFIG["cache"]["app_lifetime"]
-APP_LIST_UPDATE_INTERVAL = DEFAULT_CONFIG["ui"]["app_list_update_interval"]
-TIME_UPDATE_INTERVAL = DEFAULT_CONFIG["ui"]["time_update_interval"]
-STATUS_BAR_WIDTH = DEFAULT_CONFIG["ui"]["status_bar_width"]
-STATUS_BAR_HEIGHT = DEFAULT_CONFIG["ui"]["status_bar_height"]
-ICON_SIZE = DEFAULT_CONFIG["ui"]["icon_size"]
-DATA_RETENTION_DAYS = DEFAULT_CONFIG["data_management"]["retention_days"]
-
 # 설정 로드 함수
 def load_config():
     """설정 파일을 로드하거나 기본값을 반환합니다."""
     if not os.path.exists(DATA_DIR):
-        os.makedirs(DATA_DIR)
-        
+        os.makedirs(DATA_DIR, exist_ok=True)
+
     if os.path.exists(CONFIG_FILE):
         try:
             with open(CONFIG_FILE, 'r', encoding='utf-8') as f:
                 user_config = json.load(f)
-                
+
             # 기본 설정과 사용자 설정 병합
             config = DEFAULT_CONFIG.copy()
             for section in user_config:
@@ -79,19 +69,33 @@ def load_config():
                         config[section] = user_config[section]
                 else:
                     config[section] = user_config[section]
-                    
+
             return config
         except Exception as e:
             logging.error(f"설정 파일 로드 중 오류 발생: {e}")
-            
+
     # 설정 파일이 없거나 오류 발생 시 기본 설정 저장
     try:
         with open(CONFIG_FILE, 'w', encoding='utf-8') as f:
             json.dump(DEFAULT_CONFIG, f, ensure_ascii=False, indent=4)
     except Exception as e:
         logging.error(f"기본 설정 파일 저장 중 오류 발생: {e}")
-        
+
     return DEFAULT_CONFIG
+
+
+def save_config(config):
+    """설정을 파일에 저장합니다."""
+    try:
+        if not os.path.exists(DATA_DIR):
+            os.makedirs(DATA_DIR, exist_ok=True)
+        with open(CONFIG_FILE, 'w', encoding='utf-8') as f:
+            json.dump(config, f, ensure_ascii=False, indent=4)
+        return True
+    except Exception as e:
+        logging.error(f"설정 파일 저장 중 오류 발생: {e}")
+        return False
+
 
 # 전역 설정 객체
 CONFIG = load_config()
@@ -164,10 +168,10 @@ COMMON_STYLE = """
 def setup_logging():
     """로깅 시스템을 설정합니다."""
     if not os.path.exists(DATA_DIR):
-        os.makedirs(DATA_DIR)
-    
+        os.makedirs(DATA_DIR, exist_ok=True)
+
     log_level = getattr(logging, CONFIG["logging"]["level"], logging.INFO)
-    
+
     logging.basicConfig(
         level=log_level,
         format='%(asctime)s [%(levelname)s] %(message)s',

--- a/src/core/data_manager.py
+++ b/src/core/data_manager.py
@@ -7,25 +7,28 @@ import threading
 import time as time_module
 from datetime import datetime
 
+logger = logging.getLogger(__name__)
+
+
 class DataManager:
+    """데이터 저장 및 로드를 담당하는 싱글톤 클래스"""
     _instance = None
     _lock = threading.Lock()
-    _data_cache = {}
-    _last_save = {}
-    _save_interval = CONFIG["data_management"]["save_interval"]
-    _max_cache_size = CONFIG["cache"]["max_size"]
-    _cache_cleanup_interval = CONFIG["cache"]["cleanup_interval"]
-    _last_cache_cleanup = 0
-    
-    @classmethod
-    def get_instance(cls):
+
+    def __new__(cls):
         if cls._instance is None:
             with cls._lock:
                 if cls._instance is None:
-                    cls._instance = cls()
+                    instance = super().__new__(cls)
+                    instance._initialized = False
+                    cls._instance = instance
         return cls._instance
-    
+
     def __init__(self):
+        if self._initialized:
+            return
+        self._initialized = True
+
         self.ensure_data_directory()
         self._data_cache = {
             'app_usage': None,
@@ -41,99 +44,99 @@ class DataManager:
         }
         self._cache_size = 0
         self._last_cache_cleanup = time_module.time()
-    
+
+        self._save_interval = CONFIG["data_management"]["save_interval"]
+        self._max_cache_size = CONFIG["cache"]["max_size"]
+        self._cache_cleanup_interval = CONFIG["cache"]["cleanup_interval"]
+
     def _update_cache_size(self, data):
         """캐시 크기를 업데이트하고 제한을 확인합니다."""
         try:
             data_size = len(json.dumps(data))
             if data_size > self._max_cache_size:
-                logging.warning(f"데이터 크기({data_size}바이트)가 캐시 제한({self._max_cache_size}바이트)을 초과했습니다.")
+                logger.warning(f"데이터 크기({data_size}바이트)가 캐시 제한({self._max_cache_size}바이트)을 초과했습니다.")
                 return False
             self._cache_size = data_size
-            
+
             # 주기적으로 캐시 정리 수행
             current_time = time_module.time()
             if current_time - self._last_cache_cleanup > self._cache_cleanup_interval:
                 self._cleanup_cache()
                 self._last_cache_cleanup = current_time
-                
+
             return True
         except Exception as e:
-            logging.error(f"캐시 크기 업데이트 중 오류 발생: {e}")
+            logger.error(f"캐시 크기 업데이트 중 오류 발생: {e}")
             return False
-            
+
     def _cleanup_cache(self):
         """오래된 캐시 데이터를 정리합니다."""
         try:
-            logging.info("캐시 정리 시작")
-            # 설정된 보관 기간을 기준으로 오래된 데이터 정리
             retention_days = CONFIG.get('data_management', {}).get('retention_days', 30)
             if self._data_cache['app_usage'] is not None:
                 current_date = datetime.now().date()
                 dates_to_remove = []
-                
+
                 for date_str in self._data_cache['app_usage'].get('dates', {}):
                     try:
                         date_obj = datetime.strptime(date_str, '%Y-%m-%d').date()
                         days_diff = (current_date - date_obj).days
-                        
+
                         if days_diff > retention_days:
                             dates_to_remove.append(date_str)
                     except ValueError:
-                        # 잘못된 날짜 형식은 무시
                         continue
-                
+
                 # 오래된 데이터 제거
                 for date_str in dates_to_remove:
                     del self._data_cache['app_usage']['dates'][date_str]
-                    
+
                 if dates_to_remove:
-                    logging.info(f"{len(dates_to_remove)}개의 오래된 날짜 데이터를 캐시에서 제거했습니다.")
+                    logger.info(f"{len(dates_to_remove)}개의 오래된 날짜 데이터를 캐시에서 제거했습니다.")
                     self._dirty['app_usage'] = True
-            
-            logging.info("캐시 정리 완료")
+
         except Exception as e:
-            logging.error(f"캐시 정리 중 오류 발생: {e}")
+            logger.error(f"캐시 정리 중 오류 발생: {e}")
 
     def ensure_data_directory(self):
         """데이터 디렉토리가 없으면 생성합니다."""
         if not hasattr(self, '_dir_checked'):
             if not os.path.exists(DATA_DIR):
-                os.makedirs(DATA_DIR)
+                os.makedirs(DATA_DIR, exist_ok=True)
             self._dir_checked = True
 
     def load_app_usage(self):
         """앱 사용 데이터를 로드합니다."""
         if self._data_cache['app_usage'] is not None:
             return self._data_cache['app_usage']
-            
+
         try:
             if not os.path.exists(APP_USAGE_FILE):
                 self._data_cache['app_usage'] = {'dates': {}}
                 return self._data_cache['app_usage']
-                
+
             with open(APP_USAGE_FILE, 'r', encoding='utf-8') as f:
                 data = json.load(f)
                 if self._update_cache_size(data):
                     self._data_cache['app_usage'] = data
                     return self._data_cache['app_usage']
                 else:
-                    print("앱 사용 데이터가 캐시 크기 제한을 초과했습니다")
+                    logger.warning("앱 사용 데이터가 캐시 크기 제한을 초과했습니다")
                     return data
-                
+
         except json.JSONDecodeError as e:
-            print(f"앱 사용 데이터 파일 손상: {e}")
+            logger.error(f"앱 사용 데이터 파일 손상: {e}")
             self._data_cache['app_usage'] = {'dates': {}}
             return self._data_cache['app_usage']
         except Exception as e:
-            print(f"앱 사용 데이터 로드 중 오류 발생: {e}")
+            logger.error(f"앱 사용 데이터 로드 중 오류 발생: {e}")
             self._data_cache['app_usage'] = {'dates': {}}
             return self._data_cache['app_usage']
 
     def save_app_usage(self, data):
         """앱 사용 데이터를 저장합니다."""
         current_time = time_module.time()
-        
+
         # 튜플 키를 문자열로 변환
         processed_data = {'dates': {}}
         for date, date_data in data.get('dates', {}).items():
@@ -144,18 +147,18 @@ class DataManager:
                     if isinstance(window_key, tuple):
                         window_key = '::'.join(str(k) for k in window_key)
                     processed_windows[window_key] = window_time
-                
+
                 processed_data['dates'][date][app_name] = {
                     'total_time': app_data.get('total_time', 0),
                     'windows': processed_windows,
                     'is_active': app_data.get('is_active', False),
                     'last_update': app_data.get('last_update', current_time)
                 }
-        
+
         if self._update_cache_size(processed_data):
             self._data_cache['app_usage'] = processed_data
         self._dirty['app_usage'] = True
-        
+
         # 마지막 저장 후 일정 시간이 지났을 때만 저장
         if current_time - self._last_save['app_usage'] >= self._save_interval:
             try:
@@ -166,22 +169,22 @@ class DataManager:
                         self._last_save['app_usage'] = current_time
                         self._dirty['app_usage'] = False
             except Exception as e:
-                logging.error(f"앱 사용 데이터 저장 중 오류 발생: {e}")
-                logging.error(traceback.format_exc())
+                logger.error(f"앱 사용 데이터 저장 중 오류 발생: {e}")
+                logger.error(traceback.format_exc())
                 # 오류 복구: 백업 파일 생성 시도
                 try:
                     backup_file = f"{APP_USAGE_FILE}.backup"
                     with open(backup_file, 'w', encoding='utf-8') as f:
                         json.dump(processed_data, f, ensure_ascii=False)
-                    logging.info(f"앱 사용 데이터 백업 파일 생성: {backup_file}")
+                    logger.info(f"앱 사용 데이터 백업 파일 생성: {backup_file}")
                 except Exception as backup_error:
-                    logging.critical(f"백업 파일 생성 실패: {backup_error}")
+                    logger.critical(f"백업 파일 생성 실패: {backup_error}")
 
     def load_timer_data(self):
         """타이머 데이터를 로드합니다."""
         if self._data_cache['timer_data'] is not None:
             return self._data_cache['timer_data']
-            
+
         try:
             if os.path.exists(TIMER_DATA_FILE):
                 with open(TIMER_DATA_FILE, 'r', encoding='utf-8') as f:
@@ -190,23 +193,23 @@ class DataManager:
                         self._data_cache['timer_data'] = data
                         return self._data_cache['timer_data']
                     else:
-                        logging.warning("타이머 데이터가 캐시 크기 제한을 초과했습니다")
+                        logger.warning("타이머 데이터가 캐시 크기 제한을 초과했습니다")
                         return data
         except Exception as e:
-            logging.error(f"타이머 데이터 로드 중 오류 발생: {e}")
-            logging.error(traceback.format_exc())
-            
+            logger.error(f"타이머 데이터 로드 중 오류 발생: {e}")
+            logger.error(traceback.format_exc())
+
             # 백업 파일 확인
             backup_file = f"{TIMER_DATA_FILE}.backup"
             if os.path.exists(backup_file):
                 try:
                     with open(backup_file, 'r', encoding='utf-8') as f:
                         data = json.load(f)
-                    logging.info(f"백업 파일에서 타이머 데이터 복구 성공")
+                    logger.info("백업 파일에서 타이머 데이터 복구 성공")
                     return data
                 except Exception as backup_error:
-                    logging.error(f"백업 파일에서 타이머 데이터 복구 실패: {backup_error}")
-            
+                    logger.error(f"백업 파일에서 타이머 데이터 복구 실패: {backup_error}")
+
             # 기본 타이머 데이터 구조
             self._data_cache['timer_data'] = {
                 'app_name': None,
@@ -225,7 +228,7 @@ class DataManager:
         if self._update_cache_size(data):
             self._data_cache['timer_data'] = data
         self._dirty['timer_data'] = True
-        
+
         # 마지막 저장 후 일정 시간이 지났을 때만 저장
         if current_time - self._last_save['timer_data'] >= self._save_interval:
             try:
@@ -236,9 +239,9 @@ class DataManager:
                         self._last_save['timer_data'] = current_time
                         self._dirty['timer_data'] = False
             except (IOError, OSError) as e:
-                print(f"타이머 데이터 저장 중 I/O 오류 발생: {e}")
+                logger.error(f"타이머 데이터 저장 중 I/O 오류 발생: {e}")
             except Exception as e:
-                print(f"타이머 데이터 저장 중 예상치 못한 오류 발생: {e}")
+                logger.error(f"타이머 데이터 저장 중 예상치 못한 오류 발생: {e}")
 
     def load_recent_app_usage(self):
         """최근 7일간의 앱 사용 데이터만 로드합니다."""
@@ -246,15 +249,15 @@ class DataManager:
             usage_file = os.path.join(DATA_DIR, 'app_usage.json')
             if not os.path.exists(usage_file):
                 return None
-                
+
             with open(usage_file, 'r', encoding='utf-8') as f:
                 data = json.load(f)
-                
+
             # 최근 7일 데이터만 필터링
             if 'dates' in data:
                 current_date = datetime.now().date()
                 recent_dates = {}
-                
+
                 for date_str, usage in data['dates'].items():
                     try:
                         date = datetime.strptime(date_str, '%Y-%m-%d').date()
@@ -262,29 +265,33 @@ class DataManager:
                             recent_dates[date_str] = usage
                     except ValueError:
                         continue
-                
+
                 return {'dates': recent_dates}
             return None
-            
+
         except Exception as e:
+            logger.error(f"최근 앱 사용 데이터 로드 중 오류: {e}")
             return None
 
     @classmethod
-    def force_save_all(cls):
+    def get_instance(cls):
+        """DataManager 싱글톤 인스턴스를 반환합니다."""
+        return cls()
+
+    def force_save_all(self):
         """모든 데이터를 강제로 저장합니다."""
-        instance = cls.get_instance()
         try:
-            with instance._lock:
-                if instance._dirty['app_usage']:
+            with self._lock:
+                if self._dirty['app_usage']:
                     with open(APP_USAGE_FILE, 'w', encoding='utf-8') as f:
-                        json.dump(instance._data_cache['app_usage'], f, ensure_ascii=False)
-                    instance._dirty['app_usage'] = False
-                
-                if instance._dirty['timer_data']:
+                        json.dump(self._data_cache['app_usage'], f, ensure_ascii=False)
+                    self._dirty['app_usage'] = False
+
+                if self._dirty['timer_data']:
                     with open(TIMER_DATA_FILE, 'w', encoding='utf-8') as f:
-                        json.dump(instance._data_cache['timer_data'], f, ensure_ascii=False)
-                    instance._dirty['timer_data'] = False
+                        json.dump(self._data_cache['timer_data'], f, ensure_ascii=False)
+                    self._dirty['timer_data'] = False
         except (IOError, OSError) as e:
-            print(f"강제 저장 중 I/O 오류 발생: {e}")
+            logger.error(f"강제 저장 중 I/O 오류 발생: {e}")
         except Exception as e:
-            print(f"강제 저장 중 예상치 못한 오류 발생: {e}")
+            logger.error(f"강제 저장 중 예상치 못한 오류 발생: {e}")

--- a/src/core/status_bar.py
+++ b/src/core/status_bar.py
@@ -2,11 +2,12 @@ import objc
 import time
 from Foundation import NSObject, NSMakeRect, NSMakePoint, NSMakeSize, NSAttributedString, NSFont
 from AppKit import (NSStatusBar, NSVariableStatusItemLength, NSImage, NSMenuItem, NSMenu,
-                   NSView, NSButton, NSButtonTypeMomentaryLight, NSTextField, 
+                   NSView, NSButton, NSButtonTypeMomentaryLight, NSTextField,
                    NSTextAlignmentCenter, NSColor, NSBezierPath, NSFontWeightBold)
 from PyQt5.QtCore import QTimer
 
-from src.core.config import APP_NAME, BUNDLE_ID, STATUS_BAR_WIDTH, STATUS_BAR_HEIGHT, ICON_SIZE
+from src.core.config import APP_NAME, BUNDLE_ID, CONFIG
+
 
 class StatusBarController(NSObject):
     def init(self):
@@ -24,46 +25,53 @@ class StatusBarController(NSObject):
         self.statusItem.setHighlightMode_(True)
 
     def _setup_custom_view(self):
+        ui_config = CONFIG["ui"]
+        status_bar_width = ui_config["status_bar_width"]
+        status_bar_height = ui_config["status_bar_height"]
+        icon_size = ui_config["icon_size"]
+
         self.custom_view = NSView.alloc().initWithFrame_(
-            NSMakeRect(0, 0, STATUS_BAR_WIDTH, STATUS_BAR_HEIGHT))
-        
+            NSMakeRect(0, 0, status_bar_width, status_bar_height))
+
         # 아이콘 설정
         self.icon_view = NSButton.alloc().initWithFrame_(
-            NSMakeRect(0, 0, ICON_SIZE, ICON_SIZE))
+            NSMakeRect(0, 0, icon_size, icon_size))
         self.icon_view.setButtonType_(NSButtonTypeMomentaryLight)
         self.icon_view.setBordered_(False)
         icon_image = NSImage.alloc().initWithSize_(
-            NSMakeSize(ICON_SIZE, ICON_SIZE))
+            NSMakeSize(icon_size, icon_size))
         icon_image.lockFocus()
-        self.draw_clock_icon()
+        self.draw_clock_icon(icon_size)
         icon_image.unlockFocus()
         self.icon_view.setImage_(icon_image)
         self.icon_view.setTarget_(self)
         self.icon_view.setAction_(objc.selector(self.iconClicked_, signature=b'v@:'))
         self.custom_view.addSubview_(self.icon_view)
-        
+
         # 시간 레이블 설정
         self.time_label = NSTextField.alloc().initWithFrame_(
-            NSMakeRect(24, 2, STATUS_BAR_WIDTH - ICON_SIZE - 2, STATUS_BAR_HEIGHT - 4))
+            NSMakeRect(icon_size + 4, 2,
+                       status_bar_width - icon_size - 6,
+                       status_bar_height - 4))
         self.time_label.setBezeled_(False)
         self.time_label.setDrawsBackground_(False)
         self.time_label.setEditable_(False)
         self.time_label.setSelectable_(False)
         self.time_label.setAlignment_(NSTextAlignmentCenter)
-        
+
         # 폰트 설정
         font = NSFont.monospacedDigitSystemFontOfSize_weight_(12, NSFontWeightBold)
         self.time_label.setFont_(font)
-        
+
         self.time_label.setStringValue_("00:00:00")
         self.time_label.setToolTip_("현재 앱 사용 시간")
         self.custom_view.addSubview_(self.time_label)
-        
+
         self.statusItem.setView_(self.custom_view)
 
-    def draw_clock_icon(self):
+    def draw_clock_icon(self, icon_size):
         """시계 아이콘을 그립니다."""
-        width, height = ICON_SIZE, ICON_SIZE
+        width, height = icon_size, icon_size
         NSColor.blackColor().set()
         path = NSBezierPath.bezierPathWithOvalInRect_(
             NSMakeRect(1, 1, width-2, height-2))
@@ -103,8 +111,8 @@ class StatusBarController(NSObject):
         """상태바의 시간 표시를 업데이트합니다."""
         formatted_time = self._format_time(time_text)
         self.time_label.setStringValue_(formatted_time)
-        
-        # 툴크 업데이트
+
+        # 툴팁 업데이트
         hours = int(time_text.split(":")[0])
         if hours > 0:
             tooltip = f"현재 앱 사용 시간: {hours}시간 {time_text[3:]}"

--- a/src/main.py
+++ b/src/main.py
@@ -5,6 +5,7 @@ import os
 import sys
 import traceback
 import logging
+import subprocess
 from pathlib import Path
 
 # 현재 디렉토리의 상위 디렉토리를 Python 경로에 추가
@@ -29,11 +30,11 @@ if sys.platform == "darwin":  # macOS
     try:
         pyqt_dir = os.path.dirname(PyQt5.__file__)
         platforms_dir = os.path.join(pyqt_dir, "Qt", "plugins", "platforms")
-        
+
         # Qt5 디렉토리 체크
         if not os.path.exists(platforms_dir):
             platforms_dir = os.path.join(pyqt_dir, "Qt5", "plugins", "platforms")
-        
+
         # 플랫폼 플러그인 확인
         if os.path.exists(platforms_dir) and os.path.exists(os.path.join(platforms_dir, "libqcocoa.dylib")):
             os.environ['QT_QPA_PLATFORM_PLUGIN_PATH'] = platforms_dir
@@ -43,26 +44,62 @@ if sys.platform == "darwin":  # macOS
 
 from src.ui.timer_king import TimerKing
 from src.core.data_manager import DataManager
-from src.core.config import APP_NAME, BUNDLE_ID, setup_logging
+from src.core.config import APP_NAME, BUNDLE_ID, setup_logging, APP_VERSION
 import objc
 from Foundation import NSBundle
+
+logger = logging.getLogger(__name__)
+
+
+def check_accessibility_permission():
+    """macOS Accessibility 권한이 있는지 확인하고, 없으면 사용자에게 안내합니다.
+
+    Returns:
+        bool: Accessibility 권한이 있는 경우 True
+    """
+    try:
+        result = subprocess.run(
+            ['osascript', '-e',
+             'tell application "System Events" to get name of every process'],
+            capture_output=True, text=True, timeout=3.0
+        )
+        if result.returncode != 0:
+            QMessageBox.warning(
+                None, "권한 필요",
+                "Mac Time Tracker가 앱 사용 시간을 추적하려면 "
+                "Accessibility 접근 권한이 필요합니다.\n\n"
+                "설정 방법:\n"
+                "1. 시스템 환경설정 → 개인정보 보호 및 보안 → 손쉬운 사용\n"
+                "2. Mac Time Tracker (또는 터미널) 추가\n"
+                "3. 체크박스 활성화\n\n"
+                "권한이 없으면 앱 사용 시간 데이터가 수집되지 않습니다."
+            )
+            return False
+        return True
+    except subprocess.TimeoutExpired:
+        logger.warning("Accessibility 권한 확인 시간 초과")
+        return False
+    except Exception as e:
+        logger.warning(f"Accessibility 권한 확인 실패: {e}")
+        return False
+
 
 def main():
     """앱의 메인 진입점입니다."""
     # 로깅 시스템 초기화
     setup_logging()
     logger = logging.getLogger(__name__)
-    
+
     try:
         # 데이터 매니저 초기화
         data_manager = DataManager.get_instance()
         data_manager.ensure_data_directory()
-        
+
         # 앱 실행
         app = QApplication(sys.argv)
         app.setQuitOnLastWindowClosed(False)
         app.setApplicationName(APP_NAME)
-        
+
         # macOS 앱 설정
         bundle = NSBundle.mainBundle()
         info = bundle.localizedInfoDictionary() or bundle.infoDictionary()
@@ -70,23 +107,29 @@ def main():
             info['CFBundleName'] = APP_NAME
             info['CFBundleIdentifier'] = BUNDLE_ID
             info['LSUIElement'] = True  # dock 아이콘 숨기기
-        
+
+        # Accessibility 권한 확인 (비차단, 실패해도 앱은 실행)
+        has_access = check_accessibility_permission()
+        if not has_access:
+            logger.warning("Accessibility 권한 없음 - 창 제목 추적이 제한됩니다.")
+
         # 메인 윈도우 생성
         main_window = TimerKing()
         main_window.show()
-        
+
         # 앱 종료 시 정리 작업 추가
         app.aboutToQuit.connect(lambda: main_window._save_all_data())
-        
+
         sys.exit(app.exec_())
-        
+
     except Exception as e:
         logger.error(f"치명적 오류 발생: {e}")
         logger.error(traceback.format_exc())
-        
+
         # GUI 오류 메시지 표시 (앱 초기화가 완료된 경우)
         if 'app' in locals():
             QMessageBox.critical(None, "오류", f"앱 실행 중 오류가 발생했습니다:\n{str(e)}")
+
 
 if __name__ == '__main__':
     main()

--- a/src/ui/timer_king.py
+++ b/src/ui/timer_king.py
@@ -1,5 +1,6 @@
 import time as time_module
-from PyQt5.QtWidgets import (QMainWindow, QWidget, QVBoxLayout, QHBoxLayout, 
+import subprocess
+from PyQt5.QtWidgets import (QMainWindow, QWidget, QVBoxLayout, QHBoxLayout,
                             QPushButton, QLabel, QApplication, QMenu, QAction, QMessageBox,
                             QActionGroup, QMenuBar)
 from PyQt5.QtCore import Qt, QTimer, QSettings
@@ -7,8 +8,10 @@ from PyQt5.QtGui import QFont
 import os
 import json
 import sys
+import shlex
+import logging
 
-from src.core.config import *
+from src.core.config import APP_NAME, BUNDLE_ID, APP_VERSION, COMMON_STYLE, CONFIG, APP_USAGE_FILE, save_config
 from src.core.data_manager import DataManager
 from src.core.app_tracker import AppTracker
 from src.core.timer_manager import TimerManager
@@ -23,37 +26,40 @@ import Cocoa
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 
+logger = logging.getLogger(__name__)
+
+
 class TimerKing(QMainWindow):
     def __init__(self):
         super().__init__()
         self.setAttribute(Qt.WA_QuitOnClose, False)
         self.setAttribute(Qt.WA_DeleteOnClose, False)
-        
+
         # 초기화 플래그
         self._is_shutting_down = False
         self._initialization_complete = False
-        
+
         # 데이터 매니저 초기화
         self.data_manager = DataManager.get_instance()
-        
+
         # UI 초기화
         self.initUI()
-        
+
         # 앱 트래커 초기화 (앱 추적 로직 담당)
         self.app_tracker = AppTracker(self.data_manager)
-        
+
         # 타이머 매니저 초기화 (타이머 로직 담당)
         self.timer_manager = TimerManager(self.data_manager)
-        
+
         # UI 컨트롤러 초기화 (UI 관련 로직 담당)
         self.ui_controller = UIController(
-            self, 
-            self.home_widget, 
+            self,
+            self.home_widget,
             self.time_track_widget,
-            self.timer_manager, 
+            self.timer_manager,
             self.app_tracker
         )
-        
+
         # 비동기 초기화 시작
         self._start_async_initialization()
 
@@ -68,20 +74,19 @@ class TimerKing(QMainWindow):
     def _save_all_data(self):
         """모든 데이터를 저장하고 종료 준비를 합니다."""
         try:
-            print("앱 종료 중... 데이터 저장")
-            
+            logger.info("앱 종료 중... 데이터 저장")
+
             # 모든 데이터 저장
             self.ui_controller.save_all_data()
-            
+
             # 저장 확인
             if os.path.exists(APP_USAGE_FILE):
-                print(f"데이터 파일 저장됨: {APP_USAGE_FILE}")
-                print(f"파일 크기: {os.path.getsize(APP_USAGE_FILE)} bytes")
-            
-            print("데이터 저장 완료")
-                
+                logger.info(f"데이터 파일 저장됨: {APP_USAGE_FILE} ({os.path.getsize(APP_USAGE_FILE)} bytes)")
+
+            logger.info("데이터 저장 완료")
+
         except Exception as e:
-            print(f"앱 종료 중 오류 발생: {e}")
+            logger.error(f"앱 종료 중 오류 발생: {e}")
             import traceback
             traceback.print_exc()
 
@@ -91,7 +96,7 @@ class TimerKing(QMainWindow):
         self.async_timer.timeout.connect(self._async_init_step)
         self.async_timer.start(500)  # 500ms로 설정
         self._init_step = 0
-        
+
     def _async_init_step(self):
         """초기화 단계를 순차적으로 실행합니다."""
         if self._init_step == 0:
@@ -99,36 +104,36 @@ class TimerKing(QMainWindow):
             timer_data = self.data_manager.load_timer_data()
             self.timer_manager.timer_data = timer_data
             self._init_step += 1
-            
+
         elif self._init_step == 1:
             # 최근 사용 데이터만 로드
             recent_usage = self.data_manager.load_recent_app_usage()
             if recent_usage:
                 self.app_tracker.app_usage.update(recent_usage)
             self._init_step += 1
-            
+
         elif self._init_step == 2:
             # 앱 리스트 초기 업데이트
             self.ui_controller.update_app_list()
             self._init_step += 1
-            
+
         elif self._init_step == 3:
             # 나머지 데이터 백그라운드 로드 시작
             self._load_remaining_data_async()
             self._init_step += 1
             self._initialization_complete = True
             self.async_timer.stop()
-            
+
     def _load_remaining_data_async(self):
         """나머지 앱 사용 데이터를 백그라운드에서 로드합니다."""
         def load_data():
             full_usage = self.data_manager.load_app_usage()
             return full_usage
-            
+
         self.thread_pool = ThreadPoolExecutor(max_workers=1)
         future = self.thread_pool.submit(load_data)
         future.add_done_callback(self._on_data_loaded)
-        
+
     def _on_data_loaded(self, future):
         """백그라운드 데이터 로딩이 완료되면 호출됩니다."""
         try:
@@ -136,7 +141,7 @@ class TimerKing(QMainWindow):
             if full_usage:
                 self.app_tracker.app_usage.update(full_usage)
         except Exception as e:
-            print(f"데이터 로딩 중 오류 발생: {e}")
+            logger.error(f"데이터 로딩 중 오류 발생: {e}")
             import traceback
             traceback.print_exc()
 
@@ -145,27 +150,27 @@ class TimerKing(QMainWindow):
         self.setWindowTitle('타임 트래커')
         self.setMinimumSize(600, 400)
         self.resize(1024, 768)
-        
+
         # 기본 위젯 초기화
         self.home_widget = HomeWidget(self)
         self.time_track_widget = TimerWidget()
-        
+
         # 중앙 위젯 설정
         central_widget = QWidget()
         self.setCentralWidget(central_widget)
         layout = QVBoxLayout(central_widget)
         layout.addWidget(self.home_widget)
-        
+
         # Timer 위젯 설정 (창 옵션만 설정, 이벤트는 UIController에서 처리)
         self.time_track_widget.setWindowFlags(Qt.Window | Qt.WindowStaysOnTopHint)
-        
+
         # 스타일시트 설정
         self.setStyleSheet(COMMON_STYLE)
 
         # 메뉴바 설정
         self.menubar = QMenuBar(self)
         self.setMenuBar(self.menubar)
-        
+
         # 설정 메뉴 추가
         settings_menu = self._create_settings_menu()
         self.menubar.addMenu(settings_menu)
@@ -174,24 +179,24 @@ class TimerKing(QMainWindow):
         """소멸자에서 스레드 풀 정리"""
         if hasattr(self, 'thread_pool'):
             self.thread_pool.shutdown(wait=False)
-            
+
         # 모든 데이터 저장
         self._save_all_data()
 
     def _create_settings_menu(self):
         """설정 메뉴를 생성합니다."""
         settings_menu = QMenu("설정", self)
-        
+
         # 자동 시작 설정
         autostart_action = QAction("시스템 시작 시 자동 실행", self)
         autostart_action.setCheckable(True)
         autostart_action.setChecked(self._is_autostart_enabled())
         autostart_action.triggered.connect(self._toggle_autostart)
         settings_menu.addAction(autostart_action)
-        
+
         # 데이터 보관 기간 설정
         data_retention_menu = QMenu("데이터 보관 기간", self)
-        
+
         # 보관 기간 옵션들
         retention_options = [
             ("7일", 7),
@@ -202,27 +207,27 @@ class TimerKing(QMainWindow):
             ("180일", 180),
             ("365일", 365)
         ]
-        
+
         # 현재 설정된 보관 기간 가져오기
-        from src.core.config import DATA_RETENTION_DAYS
-        
+        current_retention_days = CONFIG["data_management"]["retention_days"]
+
         # 보관 기간 액션 그룹 생성
         retention_group = QActionGroup(self)
         retention_group.setExclusive(True)
-        
+
         for label, days in retention_options:
             action = QAction(label, self)
             action.setCheckable(True)
-            action.setChecked(days == DATA_RETENTION_DAYS)
+            action.setChecked(days == current_retention_days)
             action.setData(days)
             retention_group.addAction(action)
             data_retention_menu.addAction(action)
-        
+
         # 보관 기간 변경 시 호출될 함수 연결
         retention_group.triggered.connect(self._set_data_retention_period)
-        
+
         settings_menu.addMenu(data_retention_menu)
-        
+
         return settings_menu
 
     def _set_data_retention_period(self, action):
@@ -237,26 +242,25 @@ class TimerKing(QMainWindow):
         """시스템 시작 시 자동 실행 여부를 확인합니다."""
         settings = QSettings("ksbelphegor", "Mac_Timetracker")
         return settings.value("autostart", False, type=bool)
-    
+
     def _toggle_autostart(self, enabled):
-        """시스템 시작 시 자동 실행 설정을 토글합니다."""
+        """시스템 시작 시 자동 실행 설정을 토글합니다.
+        
+        launchctl을 사용하여 macOS LaunchAgents plist를 관리합니다.
+        """
         settings = QSettings("ksbelphegor", "Mac_Timetracker")
         settings.setValue("autostart", enabled)
-        
-        # macOS 자동 시작 설정
-        import os
-        from pathlib import Path
-        
+
         # 앱 실행 파일 경로
         app_path = os.path.abspath(sys.argv[0])
-        
+
         # LaunchAgents 디렉토리 경로
         launch_agents_dir = os.path.expanduser("~/Library/LaunchAgents")
         os.makedirs(launch_agents_dir, exist_ok=True)
-        
+
         # plist 파일 경로
         plist_path = os.path.join(launch_agents_dir, "com.ksbelphegor.mactimetracker.plist")
-        
+
         if enabled:
             # plist 파일 생성
             plist_content = f"""<?xml version="1.0" encoding="UTF-8"?>
@@ -268,7 +272,7 @@ class TimerKing(QMainWindow):
     <key>ProgramArguments</key>
     <array>
         <string>python3</string>
-        <string>{app_path}</string>
+        <string>{shlex.quote(app_path)}</string>
     </array>
     <key>RunAtLoad</key>
     <true/>
@@ -279,15 +283,25 @@ class TimerKing(QMainWindow):
 """
             with open(plist_path, "w") as f:
                 f.write(plist_content)
-                
+
             # launchctl에 등록
-            os.system(f"launchctl load {plist_path}")
-            
+            result = subprocess.run(
+                ["launchctl", "load", plist_path],
+                capture_output=True, text=True, timeout=10
+            )
+            if result.returncode != 0:
+                logger.error(f"launchctl load 실패: {result.stderr.strip()}")
+
             QMessageBox.information(self, "자동 시작 설정", "시스템 시작 시 자동으로 실행되도록 설정되었습니다.")
         else:
             # launchctl에서 제거
             if os.path.exists(plist_path):
-                os.system(f"launchctl unload {plist_path}")
+                result = subprocess.run(
+                    ["launchctl", "unload", plist_path],
+                    capture_output=True, text=True, timeout=10
+                )
+                if result.returncode != 0:
+                    logger.error(f"launchctl unload 실패: {result.stderr.strip()}")
                 os.remove(plist_path)
-                
+
             QMessageBox.information(self, "자동 시작 설정", "시스템 시작 시 자동 실행 설정이 해제되었습니다.")

--- a/src/ui/ui_controller.py
+++ b/src/ui/ui_controller.py
@@ -5,11 +5,15 @@ import objc
 from AppKit import NSWorkspace, NSMenu, NSMenuItem, NSStatusBar
 import logging
 import os
-import re
+
+from src.core.config import CONFIG, save_config
+
+logger = logging.getLogger(__name__)
+
 
 class UIController:
     """UI 관련 로직을 처리하는 클래스"""
-    
+
     def __init__(self, main_window, home_widget, time_track_widget, timer_manager, app_tracker):
         """UIController 초기화"""
         self.main_window = main_window
@@ -17,110 +21,110 @@ class UIController:
         self.time_track_widget = time_track_widget
         self.timer_manager = timer_manager
         self.app_tracker = app_tracker
-        
+
         # StatusBarController 초기화
         self.status_bar_controller = StatusBarController.alloc().init()
         self.create_status_bar_menu()
-        
+
         # 타이머 설정 (UI 업데이트용)
         self.timer = QTimer(main_window)
         self.timer.timeout.connect(self.update_time)
         self.timer.start(1000)  # 1초로 설정
-        
+
         # 앱 업데이트 타이머
         self.app_update_timer = QTimer(main_window)
         self.app_update_timer.timeout.connect(self.update_app_list)
         self.app_update_timer.start(10000)  # 10초 유지
-        
+
         # 자동 저장 타이머
         self.autosave_timer = QTimer(main_window)
         self.autosave_timer.timeout.connect(self.autosave_data)
         self.autosave_timer.start(30000)  # 30초마다 저장
-        
+
         # UI 업데이트 최적화를 위한 변수
         self._last_ui_update = 0
         self._ui_update_interval = 0.5  # 0.5초 유지
-        
+
         # 이벤트 연결
         self.connect_events()
-    
+
     def connect_events(self):
         """이벤트 핸들러를 연결합니다."""
         # Timer 위젯 이벤트 연결
         self.time_track_widget.reset_button.clicked.connect(self.reset_timer)
         self.time_track_widget.app_combo.currentTextChanged.connect(self.on_app_selected)
-    
+
     def create_status_bar_menu(self):
         """상태바 메뉴를 생성합니다."""
         # 상태바 메뉴 생성
         menu = NSMenu.alloc().init()
-        
+
         # 홈 메뉴 항목
         home_item = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(
             "홈", objc.selector(self.show_home_window_, signature=b'v@:'), "")
         menu.addItem_(home_item)
-        
+
         # 타이머 메뉴 항목
         timer_item = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(
             "타이머", objc.selector(self.show_timer_window_, signature=b'v@:'), "")
         menu.addItem_(timer_item)
-        
+
         # 구분선
         menu.addItem_(NSMenuItem.separatorItem())
-        
+
         # 종료 메뉴 항목
         quit_item = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(
             "종료", objc.selector(self.quit_app_, signature=b'v@:'), "q")
         menu.addItem_(quit_item)
-        
+
         # 메뉴 설정
         self.status_bar_controller.setMenu_(menu)
-    
+
     def show_home_window_(self, sender):
         """홈 창을 표시합니다."""
         self.main_window.show()
         self.main_window.raise_()
         self.main_window.activateWindow()
-    
+
     def show_timer_window_(self, sender):
         """타이머 창을 표시합니다."""
         self.time_track_widget.show()
         self.time_track_widget.raise_()
         self.time_track_widget.activateWindow()
-    
+
     def quit_app_(self, sender):
         """앱을 종료합니다."""
         # 앱 종료 전 모든 데이터 저장
         self.save_all_data()
         QApplication.quit()
-    
+
     def save_all_data(self):
         """모든 데이터를 저장합니다."""
         # 앱 트래커의 사용 통계 업데이트
         self.app_tracker.update_usage_stats(self.timer_manager.timer_data)
-        
+
         # 데이터 저장
         self.app_tracker.save_app_usage()
         self.timer_manager.save_timer_data()
-    
+
     def update_time(self):
         """시간 표시를 업데이트합니다."""
         try:
             # timer_data가 None이거나 선택된 앱이 없으면 업데이트 안 함
             if not self.timer_manager.timer_data or not self.timer_manager.timer_data.get('app_name'):
                 return
-            
+
             # 현재 실행 중인 앱 확인
             app = NSWorkspace.sharedWorkspace().activeApplication()
             if not app:
                 return
-                
+
             app_name = app['NSApplicationName']
             is_selected_app_active = (app_name == self.timer_manager.timer_data['app_name'])
-            
+
             # 타이머 상태 업데이트
             _, state_changed = self.timer_manager.update_timer_status(is_selected_app_active)
-            
+
             # 상태가 변경된 경우 UI 스타일 업데이트
             if state_changed:
                 if is_selected_app_active:
@@ -139,63 +143,63 @@ class UIController:
                             padding: 5px;
                         }
                     """)
-            
+
             # 시간 텍스트 가져오기
             time_text = self.timer_manager.get_formatted_time()
-            
+
             # UI 업데이트
             self.status_bar_controller.update_time_display(time_text)
             self.time_track_widget.update_time_display(time_text)
-            
+
             # 필요시 배치 업데이트 처리
             if self.timer_manager.should_process_updates():
                 self.timer_manager._process_pending_updates()
-                
+
         except Exception as e:
-            print(f"시간 업데이트 중 오류 발생: {e}")
+            logger.error(f"시간 업데이트 중 오류 발생: {e}")
             import traceback
             traceback.print_exc()
-    
+
     def update_app_list(self):
         """실행 중인 앱 목록을 업데이트합니다."""
         # 앱 트래커를 통해 앱 목록 업데이트
         running_apps = self.app_tracker.update_app_list()
-        
+
         # Timer 창의 콤보박스 업데이트
         current_app = self.timer_manager.timer_data.get('app_name') if self.timer_manager.timer_data else None
         self.time_track_widget.app_combo.blockSignals(True)
         self.time_track_widget.update_app_list(running_apps, current_app)
         self.time_track_widget.app_combo.blockSignals(False)
-    
+
     def autosave_data(self):
         """데이터를 자동으로 저장합니다."""
         # 타이머 데이터 저장
         self.timer_manager.save_timer_data()
-        
+
         # 앱 사용 통계 업데이트 및 저장
         self.app_tracker.update_usage_stats(self.timer_manager.timer_data)
         self.app_tracker.save_app_usage()
-    
+
     def reset_timer(self):
         """타이머를 초기화합니다."""
         self.timer_manager.reset_timer()
         self.time_track_widget.update_time_display("00:00:00")
-    
+
     def on_app_selected(self, app_name):
         """앱 선택 이벤트 처리"""
         if not app_name:
             return
-            
+
         # 현재 실행 중인 앱인지 확인
         active_app = NSWorkspace.sharedWorkspace().activeApplication()
         is_target_app_active = active_app and active_app['NSApplicationName'] == app_name
-        
+
         # 타이머 매니저에 앱 선택 알림
         self.timer_manager.select_app(app_name, is_target_app_active)
-        
+
         # UI 업데이트
         self.time_track_widget.update_time_display("00:00:00")
-        
+
         if is_target_app_active:
             self.time_track_widget.time_frame.setStyleSheet("""
                 QFrame {
@@ -212,7 +216,7 @@ class UIController:
                     padding: 5px;
                 }
             """)
-    
+
     def cleanup(self):
         """리소스를 정리합니다."""
         # 타이머 중지
@@ -222,48 +226,28 @@ class UIController:
             self.app_update_timer.stop()
         if hasattr(self, 'autosave_timer'):
             self.autosave_timer.stop()
-        
+
         # 상태바 컨트롤러 정리
         if hasattr(self, 'status_bar_controller') and self.status_bar_controller:
             # 상태바 아이템 제거
             try:
                 NSStatusBar.systemStatusBar().removeStatusItem_(self.status_bar_controller.statusItem)
             except Exception as e:
-                print(f"상태바 제거 중 오류 발생: {e}")
-    
+                logger.error(f"상태바 제거 중 오류 발생: {e}")
+
     def update_status_bar(self):
         """상태 표시줄을 업데이트합니다."""
         if self.status_bar:
             self.status_bar.update_display()
-    
+
     def set_data_retention_period(self, days):
-        """데이터 보관 기간을 설정합니다."""
-        from src.core.config import DATA_RETENTION_DAYS
+        """데이터 보관 기간을 설정합니다.
         
-        # config.py 파일 경로
-        config_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'core', 'config.py')
-        
+        config.json을 통해 런타임에 설정을 변경합니다.
+        """
         try:
-            # config.py 파일 읽기
-            with open(config_path, 'r') as f:
-                config_content = f.read()
-            
-            # DATA_RETENTION_DAYS 값 업데이트
-            updated_content = re.sub(
-                r'DATA_RETENTION_DAYS\s*=\s*\d+',
-                f'DATA_RETENTION_DAYS = {days}',
-                config_content
-            )
-            
-            # 파일 쓰기
-            with open(config_path, 'w') as f:
-                f.write(updated_content)
-            
-            # 앱 추적 위젯에서 오래된 데이터 정리
-            if hasattr(self, 'app_tracking_widget') and self.app_tracking_widget:
-                self.app_tracking_widget.cleanup_old_data(days)
-                
-            return True
+            CONFIG["data_management"]["retention_days"] = days
+            return save_config(CONFIG)
         except Exception as e:
-            logging.error(f"데이터 보관 기간 설정 중 오류 발생: {e}")
-            return False 
+            logger.error(f"데이터 보관 기간 설정 중 오류 발생: {e}")
+            return False

--- a/src/ui/widgets/app_tracking.py
+++ b/src/ui/widgets/app_tracking.py
@@ -1,34 +1,38 @@
-from PyQt5.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QLabel, QTreeWidget, 
-                            QTreeWidgetItem, QTreeWidgetItemIterator, QHeaderView, QSizePolicy, QToolTip,
+from PyQt5.QtWidgets import (QWidget, QVBoxLayout, QHBoxLayout, QLabel, QHeaderView,
                             QListWidget, QTableWidget, QTableWidgetItem, QListWidgetItem)
-from PyQt5.QtCore import QTimer, Qt, QRect, QPoint
-from PyQt5.QtGui import QFont, QPainter, QColor, QPen
+from PyQt5.QtCore import QTimer, Qt
+from PyQt5.QtGui import QFont
 import time
 import traceback
-from datetime import datetime, timedelta
+from datetime import datetime
 from src.core.data_manager import DataManager
 import subprocess
 from Foundation import NSWorkspace
 import os
-from src.core.config import APP_NAME, DATA_RETENTION_DAYS, COMMON_STYLE
-import json
+from src.core.config import APP_NAME, COMMON_STYLE
 import logging
 from src.ui.widgets.time_graph_widget import TimeGraphWidget
 
+logger = logging.getLogger(__name__)
+
+
 class AppTrackingWidget(QWidget):
+    """앱 사용 통계를 표시하는 읽기 전용 위젯.
+
+    Note: 이 위젯은 더 이상 자체적으로 앱 사용 시간을 추적하지 않습니다.
+    AppTracker가 단일 기록자(Writer) 역할을 수행하며,
+    이 위젯은 DataManager를 통해 데이터를 읽어 UI에 표시만 합니다.
+    """
+
     def __init__(self, parent=None):
         super().__init__(parent)
-        # 초기화
         self.active_app = None
-        self.active_window = None
-        self.active_start_time = None
-        self._is_active = True
         self.current_date = datetime.now().date()
         self.selected_date = self.current_date.strftime('%Y-%m-%d')
-        
-        # 데이터 매니저 초기화
+
+        # 데이터 매니저 초기화 (읽기 전용)
         self.data_manager = DataManager.get_instance()
-        
+
         # 앱 사용 데이터 로드
         self.app_usage = self.data_manager.load_app_usage()
         if not self.app_usage:
@@ -37,209 +41,50 @@ class AppTrackingWidget(QWidget):
             self.app_usage['dates'] = {}
         if self.selected_date not in self.app_usage['dates']:
             self.app_usage['dates'][self.selected_date] = {}
-        
-        # 타이머 설정 (0.5초마다 업데이트)
-        self.timer = QTimer()
-        self.timer.timeout.connect(self.update_usage_stats)
-        self.timer.start(500)  # 0.5초마다
 
-        # 트리 업데이트 최적화를 위한 변수
+        # UI 갱신 타이머 (1초마다, 데이터 수집은 AppTracker가 담당)
+        self.ui_timer = QTimer()
+        self.ui_timer.timeout.connect(self.refresh_display)
+        self.ui_timer.start(1000)
+
+        # UI 갱신 최적화
         self._last_tree_update = 0
-        self._tree_update_interval = 2.0  # 트리 업데이트 간격을 2초로 설정
-        self._pending_tree_update = False  # 트리 업데이트 대기 상태 초기화
-        self._expanded_items = {}  # 확장된 아이템 상태를 저장할 딕셔너리
+        self._tree_update_interval = 2.0
+        self._pending_tree_update = False
+        self._expanded_items = {}
 
-    def update_usage_stats(self):
-        """현재 활성화된 앱의 사용 통계를 업데이트합니다."""
+    def refresh_display(self):
+        """AppTracker가 기록한 최신 데이터를 읽어 UI를 갱신합니다."""
         try:
-            workspace = NSWorkspace.sharedWorkspace()
-            active_app = workspace.activeApplication()
-            
-            if active_app:
-                app_name = active_app['NSApplicationName']
-                current_time = time.time()
-                current_date = datetime.now().date().strftime('%Y-%m-%d')
-                
-                # 날짜 데이터가 없으면 초기화
-                if current_date not in self.app_usage['dates']:
-                    self.app_usage['dates'][current_date] = {}
-                
-                # 창 제목 가져오기
-                window_info = self.get_active_window_title()
-                window_title = window_info[1] if isinstance(window_info, tuple) else window_info
-                
-                # 앱이 변경되었을 때
-                if app_name != self.active_app:
-                    # 이전 앱의 사용 시간 업데이트
-                    if self.active_app and self.active_start_time:
-                        elapsed = current_time - self.active_start_time
-                        if elapsed > 0 and self.active_app in self.app_usage['dates'][current_date]:
-                            self.app_usage['dates'][current_date][self.active_app]['total_time'] += elapsed
-                            
-                            # 이전 창의 현재 세션 업데이트
-                            if self.active_window and 'sessions' in self.app_usage['dates'][current_date][self.active_app]:
-                                sessions = self.app_usage['dates'][current_date][self.active_app]['sessions']
-                                if sessions and sessions[0]['window'] == self.active_window:
-                                    sessions[0]['duration'] += elapsed
-                                    sessions[0]['end_time'] = datetime.now().strftime('%H:%M:%S')
-                
-                    # 앱 데이터 초기화 또는 업데이트
-                    if app_name not in self.app_usage['dates'][current_date]:
-                        self.app_usage['dates'][current_date][app_name] = {
-                            'total_time': 0,
-                            'windows': {},
-                            'start_times': [],
-                            'sessions': []  # 세션 목록 추가
-                        }
-                    else:
-                        # 기존 앱 데이터에 필요한 키가 없으면 추가
-                        if 'sessions' not in self.app_usage['dates'][current_date][app_name]:
-                            self.app_usage['dates'][current_date][app_name]['sessions'] = []
-                        if 'start_times' not in self.app_usage['dates'][current_date][app_name]:
-                            self.app_usage['dates'][current_date][app_name]['start_times'] = []
-                    
-                    # windows 딕셔너리에 창 제목 추가
-                    if window_title:
-                        # 창 제목이 앱 이름과 같은지 확인
-                        if window_title == app_name:
-                            # 앱 전환 후 약간의 지연을 추가하여 더 정확한 창 제목을 가져올 수 있도록 함
-                            time.sleep(0.2)
-                            # 더 정확한 창 제목 가져오기 시도
-                            better_title = self.get_app_window_title(app_name)
-                            if better_title and better_title != app_name:
-                                window_title = better_title
-                        
-                        if window_title not in self.app_usage['dates'][current_date][app_name]['windows']:
-                            self.app_usage['dates'][current_date][app_name]['windows'][window_title] = 0
-                        
-                        # 새 세션 추가
-                        current_time_str = datetime.now().strftime('%H:%M:%S')
-                        new_session = {
-                            'window': window_title,
-                            'start_time': current_time_str,
-                            'end_time': current_time_str,  # 초기값은 시작 시간과 동일
-                            'duration': 0  # 초기 지속 시간은 0
-                        }
-                        self.app_usage['dates'][current_date][app_name]['sessions'].insert(0, new_session)
-                    
-                    # 현재 시간을 시작 시간 목록의 맨 앞에 추가 (기존 호환성 유지)
-                    current_time_str = datetime.now().strftime('%H:%M:%S')
-                    self.app_usage['dates'][current_date][app_name]['start_times'].insert(0, current_time_str)
-                    
-                    self.active_app = app_name
-                    self.active_window = window_title
-                    self.active_start_time = current_time
-                else:
-                    # 같은 앱을 계속 사용 중인 경우에도 시간 업데이트
-                    if self.active_app and self.active_start_time:
-                        elapsed = current_time - self.active_start_time
-                        if elapsed > 0 and self.active_app in self.app_usage['dates'][current_date]:
-                            # 필요한 키가 없으면 추가
-                            if 'start_times' not in self.app_usage['dates'][current_date][self.active_app]:
-                                self.app_usage['dates'][current_date][self.active_app]['start_times'] = []
-                            if 'sessions' not in self.app_usage['dates'][current_date][self.active_app]:
-                                self.app_usage['dates'][current_date][self.active_app]['sessions'] = []
-                            
-                            # 현재 시간까지의 사용 시간을 업데이트
-                            self.app_usage['dates'][current_date][self.active_app]['total_time'] += elapsed
-                            
-                            # 창이 변경되었는지 확인
-                            if window_title != self.active_window:
-                                # 이전 창의 시간 업데이트
-                                if self.active_window in self.app_usage['dates'][current_date][self.active_app]['windows']:
-                                    self.app_usage['dates'][current_date][self.active_app]['windows'][self.active_window] += elapsed
-                                
-                                # 이전 세션 업데이트
-                                if 'sessions' in self.app_usage['dates'][current_date][self.active_app]:
-                                    sessions = self.app_usage['dates'][current_date][self.active_app]['sessions']
-                                    if sessions and sessions[0]['window'] == self.active_window:
-                                        sessions[0]['duration'] += elapsed
-                                        sessions[0]['end_time'] = datetime.now().strftime('%H:%M:%S')
-                                
-                                # 새 창 추가
-                                if window_title not in self.app_usage['dates'][current_date][self.active_app]['windows']:
-                                    self.app_usage['dates'][current_date][self.active_app]['windows'][window_title] = 0
-                                
-                                # 새 세션 추가
-                                current_time_str = datetime.now().strftime('%H:%M:%S')
-                                new_session = {
-                                    'window': window_title,
-                                    'start_time': current_time_str,
-                                    'end_time': current_time_str,
-                                    'duration': 0
-                                }
-                                self.app_usage['dates'][current_date][self.active_app]['sessions'].insert(0, new_session)
-                                
-                                # 시작 시간 추가 (기존 호환성 유지)
-                                self.app_usage['dates'][current_date][self.active_app]['start_times'].insert(0, current_time_str)
-                                
-                                self.active_window = window_title
-                            else:
-                                # 같은 창이면 해당 창의 시간만 업데이트
-                                if self.active_window in self.app_usage['dates'][current_date][self.active_app]['windows']:
-                                    self.app_usage['dates'][current_date][self.active_app]['windows'][self.active_window] += elapsed
-                                
-                                # 현재 세션 업데이트
-                                if 'sessions' in self.app_usage['dates'][current_date][self.active_app]:
-                                    sessions = self.app_usage['dates'][current_date][self.active_app]['sessions']
-                                    if sessions and sessions[0]['window'] == self.active_window:
-                                        sessions[0]['duration'] += elapsed
-                                        sessions[0]['end_time'] = datetime.now().strftime('%H:%M:%S')
-                            
-                            # 시작 시간 재설정
-                            self.active_start_time = current_time
-            
+            # DataManager에서 최신 데이터를 읽어옴 (AppTracker가 기록한 데이터)
+            fresh_data = self.data_manager.load_app_usage()
+            if fresh_data and 'dates' in fresh_data:
+                self.app_usage = fresh_data
+
+            current_date = datetime.now().date().strftime('%Y-%m-%d')
+            if current_date not in self.app_usage['dates']:
+                self.app_usage['dates'][current_date] = {}
+
+            # 날짜 갱신
+            now = datetime.now().date()
+            if now != self.current_date:
+                self.current_date = now
+                self.selected_date = now.strftime('%Y-%m-%d')
+                if self.selected_date not in self.app_usage['dates']:
+                    self.app_usage['dates'][self.selected_date] = {}
+
         except Exception as e:
-            logging.error(f"앱 사용 통계 업데이트 중 오류 발생: {e}")
-            traceback.print_exc()
+            logger.error(f"데이터 새로고침 중 오류: {e}")
 
     def save_expanded_state(self):
-        """더 이상 tree widget을 사용하지 않으므로 빈 메서드로 유지"""
         pass
 
     def restore_expanded_state(self):
-        """더 이상 tree widget을 사용하지 않으므로 빈 메서드로 유지"""
         pass
 
     def update_app_time(self, app_name=None, window_title=None, elapsed_time=None):
-        """앱 사용 시간을 업데이트합니다."""
-        try:
-            if not all([app_name, elapsed_time]) or app_name == APP_NAME:
-                return
-                
-            current_date = datetime.now().date().strftime('%Y-%m-%d')
-            
-            # 날짜 데이터가 없으면 초기화
-            if current_date not in self.app_usage['dates']:
-                self.app_usage['dates'][current_date] = {}
-            
-            # 앱 데이터가 없으면 초기화
-            if app_name not in self.app_usage['dates'][current_date]:
-                self.app_usage['dates'][current_date][app_name] = {
-                    'total_time': 0,
-                    'windows': {},
-                    'start_times': []
-                }
-            elif 'start_times' not in self.app_usage['dates'][current_date][app_name]:
-                # 기존 앱 데이터에 start_times 필드가 없으면 추가
-                self.app_usage['dates'][current_date][app_name]['start_times'] = []
-            
-            # 앱의 총 사용 시간 업데이트
-            self.app_usage['dates'][current_date][app_name]['total_time'] += elapsed_time
-            
-            # 창별 사용 시간 업데이트
-            if window_title:
-                # window_title이 튜플인 경우 첫 번째 요소만 사용
-                if isinstance(window_title, tuple):
-                    window_title = window_title[1] if len(window_title) > 1 else window_title[0]
-                    
-                if window_title not in self.app_usage['dates'][current_date][app_name]['windows']:
-                    self.app_usage['dates'][current_date][app_name]['windows'][window_title] = 0
-                self.app_usage['dates'][current_date][app_name]['windows'][window_title] += elapsed_time
-            
-        except Exception as e:
-            logging.error(f"앱 시간 업데이트 중 오류 발생: {e}")
-            traceback.print_exc()
+        """Deprecated: AppTracker가 단독으로 데이터를 기록합니다."""
+        pass
 
     def get_app_window_title(self, app_name):
         """각 앱의 현재 창/탭 제목을 가져옵니다."""
@@ -275,7 +120,7 @@ class AppTrackingWidget(QWidget):
                     end tell
                 '''
             else:
-                # 일반적인 앱용 스크립트 (더 강력한 버전)
+                # 일반적인 앱용 스크립트
                 script = f'''
                     tell application "System Events"
                         tell process "{app_name}"
@@ -295,18 +140,17 @@ class AppTrackingWidget(QWidget):
                         end tell
                     end tell
                 '''
-            
+
             # 스크립트 실행
-            result = subprocess.run(['osascript', '-e', script], 
-                                  capture_output=True, 
+            result = subprocess.run(['osascript', '-e', script],
+                                  capture_output=True,
                                   text=True,
                                   timeout=1.5)
-            
+
             window_title = result.stdout.strip()
-            
+
             # 결과가 비어있거나 앱 이름과 같으면 다른 방법 시도
             if not window_title or window_title == app_name:
-                # 대체 스크립트 시도
                 alt_script = f'''
                     tell application "System Events"
                         tell application process "{app_name}"
@@ -325,28 +169,28 @@ class AppTrackingWidget(QWidget):
                         end tell
                     end tell
                 '''
-                
-                alt_result = subprocess.run(['osascript', '-e', alt_script], 
-                                          capture_output=True, 
+
+                alt_result = subprocess.run(['osascript', '-e', alt_script],
+                                          capture_output=True,
                                           text=True,
                                           timeout=1.5)
-                
+
                 alt_window_title = alt_result.stdout.strip()
-                
+
                 if alt_window_title and alt_window_title != app_name:
                     return alt_window_title
-            
+
             if window_title and window_title != app_name:
                 return window_title
-            
+
             # 특정 앱에 대한 하드코딩된 접근 방식
             if app_name == "Cursor":
                 return "Cursor Editor"
             elif app_name == "Arc":
                 return "Arc Browser"
-            
+
             return app_name
-            
+
         except subprocess.TimeoutExpired:
             return app_name
         except Exception:
@@ -358,47 +202,44 @@ class AppTrackingWidget(QWidget):
             # Home 화면과 Timer 창 확인
             if self.isActiveWindow():
                 return "Home", "Home"
-            elif hasattr(self, 'time_track_widget') and self.time_track_widget.isActiveWindow():
-                return "Timer", "Timer"
-            
+
             workspace = NSWorkspace.sharedWorkspace()
             active_app = workspace.activeApplication()
             if not active_app:
                 return None, None
-            
+
             app_name = active_app['NSApplicationName']
             app_pid = active_app['NSApplicationProcessIdentifier']
-            
-            # 캐시 확인 (캐시 시간을 5초로 조정)
+
+            # 캐시 확인
             cache_key = f"{app_name}_{app_pid}"
             current_time = time.time()
-            
-            if (hasattr(self, '_window_title_cache') and 
-                cache_key in self._window_title_cache and 
+
+            if (hasattr(self, '_window_title_cache') and
+                cache_key in self._window_title_cache and
                 current_time - self._window_title_cache[cache_key]['time'] < 5.0):
                 cached_title = self._window_title_cache[cache_key]['title']
                 return app_name, cached_title
-            
+
             # our_pid 속성이 없는 경우 처리
             our_pid = getattr(self, 'our_pid', None)
             if our_pid is None:
                 our_pid = os.getpid()
-            
+
             # 우리 앱인 경우
             if active_app['NSApplicationProcessIdentifier'] == our_pid:
                 window_title = "Home" if self.isActiveWindow() else "Timer"
                 return app_name, window_title
-            
+
             # 시스템 앱은 제외
             skip_apps = {'Finder', 'SystemUIServer', 'loginwindow', 'Dock', 'Control Center', 'Notification Center'}
             if app_name in skip_apps:
                 return app_name, app_name
-            
+
             # 앱별 특수 처리
             if app_name in ["Safari", "Chrome", "Firefox", "Arc", "Brave Browser"]:
                 window_title = self.get_browser_window_title(app_name)
                 if window_title and window_title != app_name:
-                    # 캐시 업데이트
                     if not hasattr(self, '_window_title_cache'):
                         self._window_title_cache = {}
                     self._window_title_cache[cache_key] = {
@@ -406,12 +247,9 @@ class AppTrackingWidget(QWidget):
                         'time': current_time
                     }
                     return app_name, window_title
-            
-            # 일반적인 방법으로 창 제목 가져오기
+
+            # AppleScript로 창 제목 가져오기
             try:
-                # 약간의 지연을 추가하여 앱이 완전히 활성화되도록 함
-                time.sleep(0.1)
-                
                 script = f'''
                     tell application "System Events"
                         tell process "{app_name}"
@@ -430,26 +268,24 @@ class AppTrackingWidget(QWidget):
                         end tell
                     end tell
                 '''
-                
-                result = subprocess.run(['osascript', '-e', script], 
-                                      capture_output=True, 
+
+                result = subprocess.run(['osascript', '-e', script],
+                                      capture_output=True,
                                       text=True,
                                       timeout=1.0)
-                
+
                 window_title = result.stdout.strip()
                 if result.returncode == 0 and window_title and window_title != app_name:
-                    # 캐시 업데이트
                     if not hasattr(self, '_window_title_cache'):
                         self._window_title_cache = {}
                     self._window_title_cache[cache_key] = {
                         'title': window_title,
                         'time': current_time
                     }
-                    
                     return app_name, window_title
-            except:
+            except Exception:
                 pass
-            
+
             # 대체 방법 시도
             try:
                 alt_script = f'''
@@ -464,26 +300,24 @@ class AppTrackingWidget(QWidget):
                         end tell
                     end tell
                 '''
-                
-                alt_result = subprocess.run(['osascript', '-e', alt_script], 
-                                          capture_output=True, 
+
+                alt_result = subprocess.run(['osascript', '-e', alt_script],
+                                          capture_output=True,
                                           text=True,
                                           timeout=1.0)
-                
+
                 alt_window_title = alt_result.stdout.strip()
                 if alt_result.returncode == 0 and alt_window_title and alt_window_title != app_name:
-                    # 캐시 업데이트
                     if not hasattr(self, '_window_title_cache'):
                         self._window_title_cache = {}
                     self._window_title_cache[cache_key] = {
                         'title': alt_window_title,
                         'time': current_time
                     }
-                    
                     return app_name, alt_window_title
-            except:
+            except Exception:
                 pass
-            
+
             # 특정 앱에 대한 하드코딩된 처리
             if app_name == "Cursor":
                 return app_name, "Cursor Editor"
@@ -491,11 +325,11 @@ class AppTrackingWidget(QWidget):
                 return app_name, "VS Code Editor"
             elif app_name == "Arc":
                 return app_name, "Arc Browser"
-            
+
             return app_name, app_name
-            
+
         except Exception as e:
-            logging.error(f"활성 창 정보 가져오기 실패: {e}")
+            logger.error(f"활성 창 정보 가져오기 실패: {e}")
             return None, None
 
     def get_browser_window_title(self, browser_name):
@@ -511,18 +345,18 @@ class AppTrackingWidget(QWidget):
                     end try
                 end tell
             '''
-            
-            result = subprocess.run(['osascript', '-e', script], 
-                                  capture_output=True, 
+
+            result = subprocess.run(['osascript', '-e', script],
+                                  capture_output=True,
                                   text=True,
                                   timeout=1.0)
-            
+
             window_title = result.stdout.strip()
             if result.returncode == 0 and window_title and window_title != browser_name:
                 return window_title
-            
+
             return browser_name
-        except:
+        except Exception:
             return browser_name
 
     def update_tree_widget(self):
@@ -545,53 +379,52 @@ class AppTrackingWidget(QWidget):
 
             # 이전 정렬 상태 복원
             self.tree_widget.sortItems(sort_column, sort_order)
-            
+
             # 총 사용 시간 업데이트
             self.update_total_time()
-            
-            # 데이터 저장
-            self.data_manager.save_app_usage(self.app_usage)
-            
+
+            # 데이터 저장 (AppTracker가 담당하므로 저장하지 않음)
+
             # 확장 상태 복원
-            self.restore_expanded_state()
-            
+            # self.restore_expanded_state()
+
         except Exception as e:
-            logging.error(f"트리 위젯 업데이트 중 오류 발생: {e}")
+            logger.error(f"트리 위젯 업데이트 중 오류 발생: {e}")
             traceback.print_exc()
 
     def create_tree_items(self):
         """트리 아이템을 처음 생성합니다."""
         current_date = datetime.now().date().strftime('%Y-%m-%d')
-        
+
         for app_name, app_data in self.app_usage['dates'][current_date].items():
             if app_name == APP_NAME:  # 자기 자신은 표시하지 않음
                 continue
-                
+
             # 부모 아이템 생성
             app_item = QTreeWidgetItem(self.tree_widget)
             app_item.setText(0, app_name)  # 앱 이름
             app_item.setText(1, '')  # 시작 시간은 비워둠
             app_item.setText(2, '')  # 종료 시간은 비워둠
             app_item.setData(0, Qt.UserRole, app_name)  # 앱 이름을 데이터로 저장
-            
+
             # 총 사용 시간 계산 및 설정
             total_time = self.calculate_total_time(app_data)
             app_item.setText(3, self.format_time(total_time))
-            
+
             # 창/탭별 세부 정보
             start_times = app_data.get('start_times', [])
             windows = app_data.get('windows', {})
-            
+
             # 각 창에 대해 자식 아이템 생성
             for window_title, window_time in windows.items():
                 if window_title:  # 창 제목이 있는 경우만
                     # window_title이 튜플인 경우 첫 번째 요소만 사용
                     if isinstance(window_title, tuple):
                         window_title = window_title[1] if len(window_title) > 1 else window_title[0]
-                    
+
                     # 시작 시간을 역순으로 정렬 (최신 시간이 먼저 오도록)
                     sorted_times = sorted(start_times, reverse=True)
-                    
+
                     # 각 시작 시간에 대해 별도의 항목 생성
                     for start_time in sorted_times:
                         window_item = QTreeWidgetItem(app_item)
@@ -602,22 +435,19 @@ class AppTrackingWidget(QWidget):
                         window_item.setText(3, '')
                         # 맨 앞에 삽입
                         app_item.insertChild(0, window_item)
-        
-        # 확장 상태 복원
-        # self.restore_expanded_state()
 
     def update_tree_items(self):
         """기존 트리 아이템의 시간 정보만 업데이트합니다."""
         current_date = datetime.now().date().strftime('%Y-%m-%d')
-        
+
         # 모든 최상위 아이템(앱)을 순회
         for i in range(self.tree_widget.topLevelItemCount()):
             app_item = self.tree_widget.topLevelItem(i)
             app_name = app_item.data(0, Qt.UserRole)
-            
+
             if app_name in self.app_usage['dates'][current_date]:
                 app_data = self.app_usage['dates'][current_date][app_name]
-                
+
                 # 총 사용 시간 업데이트
                 total_time = self.calculate_total_time(app_data)
                 app_item.setText(3, self.format_time(total_time))
@@ -638,16 +468,16 @@ class AppTrackingWidget(QWidget):
             if 'dates' not in self.app_usage or current_date not in self.app_usage['dates']:
                 self.total_time_label.setText("00:00:00")
                 return
-            
+
             date_data = self.app_usage['dates'][current_date]
-            total_time = sum(app_data.get('total_time', 0) 
-                           for app_data in date_data.values() 
+            total_time = sum(app_data.get('total_time', 0)
+                           for app_data in date_data.values()
                            if isinstance(app_data, dict))
-            
+
             self.total_time_label.setText(self.format_time(total_time))
-            
+
         except Exception as e:
-            logging.error(f"총 시간 업데이트 중 오류 발생: {e}")
+            logger.error(f"총 시간 업데이트 중 오류 발생: {e}")
             traceback.print_exc()
 
     def format_time(self, seconds):
@@ -660,166 +490,114 @@ class AppTrackingWidget(QWidget):
             seconds = int(seconds % 60)
             return f"{hours:02d}:{minutes:02d}:{seconds:02d}"
         except Exception as e:
-            logging.error(f"시간 포맷팅 중 오류 발생: {e}")
+            logger.error(f"시간 포맷팅 중 오류 발생: {e}")
             return "00:00:00"
 
-    def _update_app_list(self):
-        """앱 목록을 업데이트합니다."""
-        try:
-            current_date = datetime.now().date().strftime('%Y-%m-%d')
-            if current_date not in self.app_usage['dates']:
-                return
-            
-            # 현재 선택된 앱 저장
-            current_app = self.app_list.currentItem()
-            current_app_name = current_app.data(Qt.UserRole) if current_app else None
-            
-            # 목록 업데이트 시작
-            self.app_list.blockSignals(True)
-            self.app_list.clear()
-            
-            # 앱 데이터 정렬 (사용 시간 기준)
-            app_data = []
-            for app_name, data in self.app_usage['dates'][current_date].items():
-                if app_name == APP_NAME:
-                    continue
-                total_time = data.get('total_time', 0)
-                app_data.append((app_name, total_time))
-            
-            app_data.sort(key=lambda x: x[1], reverse=True)
-            
-            # 앱 목록 추가
-            selected_item = None
-            for app_name, total_time in app_data:
-                item = QListWidgetItem()
-                item.setText(f"{app_name} ({self.format_time(total_time)})")
-                item.setData(Qt.UserRole, app_name)
-                self.app_list.addItem(item)
-                
-                # 이전에 선택된 앱과 같은 앱이면 저장
-                if app_name == current_app_name:
-                    selected_item = item
-            
-            # 이전 선택 복원
-            if selected_item:
-                self.app_list.setCurrentItem(selected_item)
-            
-            self.app_list.blockSignals(False)
-            
-        except Exception as e:
-            logging.error(f"앱 목록 업데이트 중 오류 발생: {e}")
-
-    def _on_app_selected(self, current, previous):
-        """앱이 선택되었을 때 호출됩니다."""
-        if current:
-            app_name = current.data(Qt.UserRole)
-            self._update_detail_view(app_name)
-
     def setup_style(self):
-        # 공통 스타일시트 사용
+        """공통 스타일시트를 적용합니다."""
         self.setStyleSheet(COMMON_STYLE)
 
     def cleanup_old_data(self, days_to_keep=None):
         """오래된 데이터를 정리합니다."""
         try:
-            # 설정된 보관 기간 사용 (기본값: config에서 정의한 값)
+            from src.core.config import CONFIG
             if days_to_keep is None:
-                days_to_keep = DATA_RETENTION_DAYS
-                
+                days_to_keep = CONFIG["data_management"]["retention_days"]
+
             today = datetime.now().date()
             dates_to_remove = []
-            
+
             for date_str in self.app_usage['dates']:
                 try:
                     date_obj = datetime.strptime(date_str, '%Y-%m-%d').date()
                     days_old = (today - date_obj).days
-                    
+
                     if days_old > days_to_keep:
                         dates_to_remove.append(date_str)
                 except ValueError:
-                    # 잘못된 날짜 형식은 무시
                     continue
-            
-            # 오래된 데이터 삭제
+
             for date_str in dates_to_remove:
                 del self.app_usage['dates'][date_str]
-            
+
             return len(dates_to_remove)
         except Exception as e:
-            logging.error(f"오래된 데이터 정리 중 오류 발생: {e}")
+            logger.error(f"오래된 데이터 정리 중 오류 발생: {e}")
             return 0
 
+
 class Home_app_tracking(AppTrackingWidget):
+    """홈 화면용 앱 트래킹 위젯 (읽기 전용)"""
+
     def __init__(self, parent=None, our_pid=None):
         super().__init__(parent)
-        
-        # our_pid 설정
+
         self.our_pid = our_pid or os.getpid()
-        
-        # 초기화 변수 설정
+
         self._last_time_update = time.time()
         self._update_interval = 1.0
         self.tree_widget = None  # tree_widget 사용하지 않음
-        
+
         layout = QVBoxLayout(self)
         layout.setContentsMargins(15, 15, 15, 15)
-        
+
         # UI 초기화
         self._init_ui(layout)
-        
-        # 타이머 설정
-        self.timer.setInterval(1000)
-        
+
+        # UI 타이머 설정 (1초, 데이터 수집 아님)
+        self.ui_timer.setInterval(1000)
+
         # 그래프 업데이트 타이머
         self.graph_timer = QTimer(self)
         self.graph_timer.timeout.connect(self._update_graph)
         self.graph_timer.start(1000)
-        
+
         # 초기 데이터 업데이트
         self._update_graph()
 
     def _init_ui(self, layout):
+        """UI 컴포넌트를 초기화합니다."""
         # Total 시간과 그래프를 포함하는 컨테이너
         total_graph_container = QWidget()
         total_graph_layout = QVBoxLayout(total_graph_container)
         total_graph_layout.setContentsMargins(0, 0, 0, 0)
-        
+
         # Total 시간
         total_container = QWidget()
         total_layout = QHBoxLayout(total_container)
         total_layout.setContentsMargins(0, 0, 0, 0)
-        
+
         self.total_label = QLabel("Total")
         self.total_label.setFont(QFont("Arial", 20, QFont.Bold))
         self.total_time_label = QLabel("00:00:00")
         self.total_time_label.setFont(QFont("Arial", 20, QFont.Bold))
-        
+
         total_layout.addWidget(self.total_label)
         total_layout.addStretch()
         total_layout.addWidget(self.total_time_label)
-        
+
         # 시간 그래프
         self.time_graph = TimeGraphWidget()
-        
+
         # 컨테이너에 위젯 추가
         total_graph_layout.addWidget(total_container)
         total_graph_layout.addWidget(self.time_graph)
-        
+
         # 앱 목록과 상세 정보를 포함할 컨테이너
         content_container = QWidget()
         content_layout = QHBoxLayout(content_container)
         content_layout.setContentsMargins(0, 0, 0, 0)
-        
+
         # 앱 목록 (왼쪽)
         app_list_container = QWidget()
         app_list_layout = QVBoxLayout(app_list_container)
         app_list_layout.setContentsMargins(0, 0, 0, 0)
-        
+
         # 앱 목록 레이블
         app_list_label = QLabel("Applications")
         app_list_label.setFont(QFont("Arial", 16, QFont.Bold))
         app_list_layout.addWidget(app_list_label)
-        
+
         # 앱 목록 위젯
         self.app_list = QListWidget()
         self.app_list.setFont(QFont("Arial", 14))
@@ -828,17 +606,17 @@ class Home_app_tracking(AppTrackingWidget):
         self.app_list.setUniformItemSizes(True)
         self.app_list.currentItemChanged.connect(self._on_app_selected)
         app_list_layout.addWidget(self.app_list)
-        
+
         # 상세 정보 패널 (오른쪽)
         detail_container = QWidget()
         detail_layout = QVBoxLayout(detail_container)
         detail_layout.setContentsMargins(0, 0, 0, 0)
-        
+
         # 상세 정보 레이블
         detail_label = QLabel("Details")
         detail_label.setFont(QFont("Arial", 16, QFont.Bold))
         detail_layout.addWidget(detail_label)
-        
+
         # 상세 정보 테이블
         self.detail_table = QTableWidget()
         self.detail_table.setColumnCount(3)
@@ -847,7 +625,7 @@ class Home_app_tracking(AppTrackingWidget):
         self.detail_table.verticalHeader().setVisible(False)
         self.detail_table.setVerticalScrollMode(QTableWidget.ScrollPerPixel)
         self.detail_table.setHorizontalScrollMode(QTableWidget.ScrollPerPixel)
-        
+
         # 테이블 헤더 설정
         header = self.detail_table.horizontalHeader()
         header.setSectionResizeMode(0, QHeaderView.Stretch)
@@ -855,17 +633,17 @@ class Home_app_tracking(AppTrackingWidget):
         header.setSectionResizeMode(2, QHeaderView.Fixed)
         self.detail_table.setColumnWidth(1, 100)
         self.detail_table.setColumnWidth(2, 100)
-        
+
         detail_layout.addWidget(self.detail_table)
-        
+
         # 컨테이너에 위젯 추가
         content_layout.addWidget(app_list_container, 1)
         content_layout.addWidget(detail_container, 2)
-        
+
         # 메인 레이아웃에 위젯 추가
         layout.addWidget(total_graph_container)
         layout.addWidget(content_container)
-        
+
         # 스타일 설정
         self.setup_style()
 
@@ -874,30 +652,33 @@ class Home_app_tracking(AppTrackingWidget):
         try:
             if not hasattr(self, 'time_graph') or not hasattr(self, 'app_usage'):
                 return
-            
+
             update_start = time.time()
-            
+
+            # DataManager에서 최신 데이터 읽기
+            fresh_data = self.data_manager.load_app_usage()
+            if fresh_data and 'dates' in fresh_data:
+                self.app_usage = fresh_data
+
             # 그래프 데이터 업데이트
             self.time_graph.update_data(self.app_usage)
-            
+
             # 앱 목록과 상세 정보 업데이트
             if update_start - self._last_time_update >= self._update_interval:
-                # 현재 선택된 앱 저장
                 current_app = self.app_list.currentItem()
                 current_app_name = current_app.data(Qt.UserRole) if current_app else None
-                
+
                 # 앱 목록 업데이트
                 self._update_app_list()
-                
+
                 # 선택된 앱이 있었다면 다시 선택
                 if current_app_name:
                     for i in range(self.app_list.count()):
                         item = self.app_list.item(i)
                         if item.data(Qt.UserRole) == current_app_name:
                             self.app_list.setCurrentItem(item)
-                            # 상세 정보 업데이트
                             self._update_detail_view(current_app_name)
-                
+
                 self._last_time_update = update_start
             else:
                 # 업데이트 간격이 아니더라도 선택된 앱의 상세 정보는 업데이트
@@ -905,12 +686,12 @@ class Home_app_tracking(AppTrackingWidget):
                 if current_app:
                     app_name = current_app.data(Qt.UserRole)
                     self._update_detail_view(app_name)
-            
+
             # 총 시간 업데이트
             self.update_total_time()
-            
+
         except Exception as e:
-            logging.error(f"그래프 업데이트 중 오류 발생: {e}")
+            logger.error(f"그래프 업데이트 중 오류 발생: {e}")
             traceback.print_exc()
 
     def _update_app_list(self):
@@ -919,15 +700,15 @@ class Home_app_tracking(AppTrackingWidget):
             current_date = datetime.now().date().strftime('%Y-%m-%d')
             if current_date not in self.app_usage['dates']:
                 return
-            
+
             # 현재 선택된 앱 저장
             current_app = self.app_list.currentItem()
             current_app_name = current_app.data(Qt.UserRole) if current_app else None
-            
+
             # 목록 업데이트 시작
             self.app_list.blockSignals(True)
             self.app_list.clear()
-            
+
             # 앱 데이터 정렬 (사용 시간 기준)
             app_data = []
             for app_name, data in self.app_usage['dates'][current_date].items():
@@ -935,9 +716,9 @@ class Home_app_tracking(AppTrackingWidget):
                     continue
                 total_time = data.get('total_time', 0)
                 app_data.append((app_name, total_time))
-            
+
             app_data.sort(key=lambda x: x[1], reverse=True)
-            
+
             # 앱 목록 추가
             selected_item = None
             for app_name, total_time in app_data:
@@ -945,19 +726,19 @@ class Home_app_tracking(AppTrackingWidget):
                 item.setText(f"{app_name} ({self.format_time(total_time)})")
                 item.setData(Qt.UserRole, app_name)
                 self.app_list.addItem(item)
-                
+
                 # 이전에 선택된 앱과 같은 앱이면 저장
                 if app_name == current_app_name:
                     selected_item = item
-            
+
             # 이전 선택 복원
             if selected_item:
                 self.app_list.setCurrentItem(selected_item)
-            
+
             self.app_list.blockSignals(False)
-            
+
         except Exception as e:
-            logging.error(f"앱 목록 업데이트 중 오류 발생: {e}")
+            logger.error(f"앱 목록 업데이트 중 오류 발생: {e}")
 
     def _on_app_selected(self, current, previous):
         """앱이 선택되었을 때 호출됩니다."""
@@ -971,92 +752,61 @@ class Home_app_tracking(AppTrackingWidget):
             current_date = datetime.now().date().strftime('%Y-%m-%d')
             if current_date not in self.app_usage['dates'] or app_name not in self.app_usage['dates'][current_date]:
                 return
-            
+
             app_data = self.app_usage['dates'][current_date][app_name]
-            
+
             # 세션 데이터 가져오기
             sessions = app_data.get('sessions', [])
-            
+
             # 테이블 업데이트 시작
             self.detail_table.setRowCount(0)
-            
+
             # 세션이 없는 경우 기존 방식으로 처리 (이전 버전과의 호환성)
             if not sessions:
                 windows = app_data.get('windows', {})
                 start_times = app_data.get('start_times', [])
-                
+
                 # 창별 사용 시간 표시
                 window_items = []
                 for window_title, window_time in windows.items():
-                    # 창 제목 처리
                     display_title = self._get_window_display_title(window_title)
                     window_items.append((display_title, window_time, ""))
-                
+
                 # 사용 시간 기준으로 정렬 (많이 사용한 창 먼저)
                 window_items.sort(key=lambda x: x[1], reverse=True)
-                
+
                 # 시작 시간과 창 정보 표시
                 for i, (window_title, window_time, _) in enumerate(window_items):
                     row = self.detail_table.rowCount()
                     self.detail_table.insertRow(row)
-                    
-                    # 창 제목
-                    title_item = QTableWidgetItem(str(window_title))
-                    self.detail_table.setItem(row, 0, title_item)
-                    
-                    # 시작 시간 (있는 경우)
-                    start_time = start_times[i] if i < len(start_times) else ""
-                    time_item = QTableWidgetItem(start_time)
-                    self.detail_table.setItem(row, 1, time_item)
-                    
-                    # 사용 시간
-                    duration_item = QTableWidgetItem(self.format_time(window_time))
-                    self.detail_table.setItem(row, 2, duration_item)
-            else:
-                # 현재 활성화된 창 가져오기
-                active_window = None
-                if app_name == self.active_app:
-                    active_window = self._get_window_display_title(self.active_window)
-                
-                # 세션을 시작 시간 기준으로 정렬 (최신 세션이 먼저 표시)
-                # sessions는 이미 최신 순으로 정렬되어 있으므로 그대로 사용
-                
-                # 각 세션을 개별적으로 표시
-                for session in sessions:
-                    window_title = session['window']
-                    start_time = session['start_time']
-                    duration = session['duration']
-                    
-                    # 현재 활성 세션인 경우 실시간 시간 계산
-                    if app_name == self.active_app and self._get_window_display_title(window_title) == active_window and session == sessions[0]:
-                        current_time = time.time()
-                        elapsed = current_time - self.active_start_time
-                        duration += elapsed
-                    
-                    # 창 제목 처리
-                    display_title = self._get_window_display_title(window_title)
-                    
-                    row = self.detail_table.rowCount()
-                    self.detail_table.insertRow(row)
-                    
-                    # 창 제목
-                    title_item = QTableWidgetItem(str(display_title))
-                    self.detail_table.setItem(row, 0, title_item)
-                    
-                    # 시작 시간
-                    time_item = QTableWidgetItem(start_time)
-                    self.detail_table.setItem(row, 1, time_item)
-                    
-                    # 사용 시간
-                    duration_item = QTableWidgetItem(self.format_time(duration))
-                    self.detail_table.setItem(row, 2, duration_item)
-        
-        except Exception as e:
-            logging.error(f"상세 정보 업데이트 중 오류 발생: {e}")
 
-    def setup_style(self):
-        # 공통 스타일시트 사용
-        self.setStyleSheet(COMMON_STYLE)
+                    self.detail_table.setItem(row, 0, QTableWidgetItem(window_title))
+                    self.detail_table.setItem(row, 1, QTableWidgetItem(""))
+                    self.detail_table.setItem(row, 2, QTableWidgetItem(self.format_time(window_time)))
+
+                    # 색상 구분
+                    color = QColor(50, 50, 50) if i % 2 == 0 else QColor(60, 60, 60)
+                    for col in range(self.detail_table.columnCount()):
+                        self.detail_table.item(row, col).setBackground(color)
+            else:
+                # 세션 데이터 표시
+                row = 0
+                for session in sessions:
+                    self.detail_table.insertRow(row)
+                    self.detail_table.setItem(row, 0, QTableWidgetItem(session.get('window', '')))
+                    self.detail_table.setItem(row, 1, QTableWidgetItem(session.get('start_time', '')))
+                    self.detail_table.setItem(row, 2, QTableWidgetItem(
+                        self.format_time(session.get('duration', 0))))
+
+                    # 색상 구분
+                    color = QColor(50, 50, 50) if row % 2 == 0 else QColor(60, 60, 60)
+                    for col in range(self.detail_table.columnCount()):
+                        self.detail_table.item(row, col).setBackground(color)
+                    row += 1
+
+        except Exception as e:
+            logger.error(f"상세 정보 업데이트 중 오류 발생: {e}")
+            traceback.print_exc()
 
     def _get_window_display_title(self, window_title):
         """창 제목을 표시용으로 변환합니다."""

--- a/src/ui/widgets/time_graph_widget.py
+++ b/src/ui/widgets/time_graph_widget.py
@@ -335,8 +335,8 @@ class TimeGraphWidget(QWidget):
             self.center_time = self.drag_start_time + time_delta
             self.update()
         
-        # 툴팁 표시
-        if hasattr(self.window(), 'app_usage'):
+        # 툴팁 표시 (self.app_usage 사용, window() 경유보다 안전)
+        if hasattr(self, 'app_usage') and self.app_usage:
             pos = event.pos()
             timeline_height = 30
             graph_margin = 5
@@ -350,7 +350,8 @@ class TimeGraphWidget(QWidget):
                 
                 # 해당 시점에서 실행 중인 앱 찾기
                 found_app = None
-                for app_name, app_data in self.window().app_usage.items():
+                today_str = datetime.now().strftime('%Y-%m-%d')
+                for app_name, app_data in self.app_usage.get('dates', {}).get(today_str, {}).items():
                     start_time = app_data.get('last_update', time.time()) - app_data.get('total_time', 0)
                     end_time = app_data.get('last_update', time.time())
                     


### PR DESCRIPTION
## 변경 사항 요약

### Critical Fixes

**1. 이중 추적 구조 통합**
- AppTrackingWidget이 더 이상 자체 QTimer(500ms)로 앱 사용 시간을 추적하지 않음
- AppTracker가 유일한 데이터 기록자(Writer) 역할
- AppTrackingWidget은 DataManager에서 읽기 전용(read-only)으로 데이터를 가져와 UI에 표시만 함
- app_usage.json에 동시에 쓰기(dirty write)하던 경합 상태 제거

**2. UI 스레드 time.sleep() 제거**
- AppTrackingWidget 내 time.sleep(0.1), time.sleep(0.2) 완전 제거
- 500ms QTimer 콜백 내에서 발생하던 UI 블로킹 해소

**3. os.system() -> subprocess.run()**
- timer_king.py:_toggle_autostart()에서 os.system()을 subprocess.run()으로 변경
- shlex.quote()로 경로 이스케이프 처리

**4. config 소스코드 regex 수정 제거**
- UIController.set_data_retention_period()가 더 이상 config.py 소스코드를 re.sub()로 직접 수정하지 않음
- save_config()를 통해 ~/.mactimetracker/config.json에 런타임 설정 저장

### Major Improvements

**5. print() -> logging 모듈 전환**
- app_tracker.py, data_manager.py, timer_king.py, ui_controller.py 일괄 전환
- 일관된 로그 포맷과 파일 로테이션 사용

**6. 버전 문자열 통일**
- setup.py: 1.0.1 -> 1.1.1
- config.py: 1.0.0 -> 1.1.1 (README와 일치)

**7. DataManager 싱글톤 리팩토링**
- __new__ 패턴으로 변경하여 클래스 레벨 mutable 공유 제거
- force_save_all() 인스턴스 메서드로 변경

### Minor Fixes

8. **Accessibility 권한 체크** 추가 (main.py)
9. **HOME_DIR 미사용 변수** 제거 (config.py)
10. **LICENSE 연도** 2024 -> 2026
11. **requirements.txt** trailing whitespace 제거
12. **TimeGraphWidget** self.window().app_usage -> self.app_usage로 안정화

## 영향도

- 총 13개 파일 변경, 597라인 추가 / 792라인 제거
- 데이터 스키마 변경 없음 (하위 호환성 유지)
- 기존 app_usage.json, timer_data.json 그대로 사용 가능
